### PR TITLE
Inserting a CMS Block right before the footer

### DIFF
--- a/local-intercept.js
+++ b/local-intercept.js
@@ -17,6 +17,21 @@
  * or modify functionality from its dependencies.
  */
 
-function localIntercept() {}
+const { Targetables } = require('@magento/pwa-buildpack')
 
-module.exports = localIntercept;
+module.exports = targets => {
+    const targetables = Targetables.using(targets);
+
+    const MainComponent = targetables.reactComponent(
+        '@magento/venia-ui/lib/components/Main/main.js'
+    );
+
+    const CmsBlock = MainComponent.addImport(
+        "CmsBlock from '@magento/venia-ui/lib/components/CmsBlock'"
+    );
+
+    MainComponent.insertBeforeJSX(
+    '<Footer/>',
+    `<${CmsBlock} identifiers="my-identifiers" />`
+    );
+}


### PR DESCRIPTION
Added a cms block using Targetables.
Identifiers for the cms block invented by me.
As a result, under the footer, the cms block is displayed with the content: 'The CMS block with the 'my-identifiers' ID doesn't exist.
As far as I understood, for correct content to be displayed, it needs to be added from admin area.